### PR TITLE
refactor: desacoplar componente de favorito del card

### DIFF
--- a/src/components/Favorite.vue
+++ b/src/components/Favorite.vue
@@ -1,57 +1,54 @@
+<!-- Like component  -->
+
 <script setup lang="ts">
-defineProps({
-  /**
-   * Boolean to check if the trail is a favorite
-   */
-  isFavorite: {
-    type: Boolean,
-    default: false
-  },
-  isCard: {
-    type: Boolean,
-    default: true
+withDefaults(
+  defineProps<{
+    isFavorite: boolean
+    type?: 'filled'
+  }>(),
+  {
+    isFavorite: false,
+    type: undefined
   }
-})
+)
 </script>
 
 <template>
-  <div class="favorite">
-    <i 
-      class="material-icons favorite__heart"
-      :class="{ 
-        'favorite__heart_favorite': isFavorite,
-        'favorite__heart_card': isCard
-      }"
-    >
-      {{ isFavorite ? 'favorite' : 'favorite_border'}}
+  <div class="favorite" :class="type ? `favorite--${type}` : ''">
+    <i class="material-icons favorite__heart" :class="{ 'favorite__heart--active': isFavorite }">
+      {{ isFavorite ? 'favorite' : 'favorite_border' }}
     </i>
   </div>
 </template>
 
 <style scoped lang="scss">
-
 .favorite {
   display: flex;
+  justify-content: center;
   align-items: center;
-  gap: var(--spacing-1);
+
+  &:hover {
+    transform: scale(1.1);
+    transition: transform 0.5s ease;
+  }
+
+  &--filled {
+    background-color: var(--color-background-mute);
+    border-radius: var(--size-5);
+    padding: var(--size-05);
+    box-shadow: var(--shadow);
+  }
 
   &__heart {
     color: var(--color-secondary);
-    border-radius: var(--size-5);
-    transition: color 0.5s ease, transform 0.5s ease;
-    
-    &_card {
-      color: var(--color-background);
-      margin: var(--size-05);
-      padding: var(--size-05);
-      background-color: var(--color-background-30);
-      
-    }
+    transition:
+      color 0.5s ease,
+      transform 0.5s ease;
 
-    &_favorite {
+    &--active {
       color: var(--color-highlight);
     }
-    
+
     &:hover {
       cursor: pointer;
     }

--- a/src/components/TrailCard.vue
+++ b/src/components/TrailCard.vue
@@ -24,13 +24,14 @@ const emit = defineEmits(['handle-favorite'])
 
 <template>
   <div class="card">
-    <div 
+    <div
       class="card__image"
       :style="{ backgroundImage: 'url(' + trail.pictures[0] + ')' }"
     >
-      <div>
-        <Favorite 
+      <div class="card__favorite">
+        <Favorite
           :isFavorite="isFavorite"
+          type="filled"
           @click.stop.prevent="emit('handle-favorite', trail.id)"
         />
       </div>
@@ -73,6 +74,10 @@ const emit = defineEmits(['handle-favorite'])
     margin-bottom: 1rem;
     display: flex;
     justify-content: flex-end;
+  }
+
+  &__favorite {
+    margin: var(--spacing-2);
   }
 }
 

--- a/src/views/TrailShowView.vue
+++ b/src/views/TrailShowView.vue
@@ -17,9 +17,8 @@
             <Badge icon="hiking" :text="trail.activity" />
             <div class="trail__icons">
               <Rating :score="trail.stats.rank" />
-              <Favorite 
+              <Favorite
                 :isFavorite="favoritesStore.isFavorite(trail.id)"
-                :isCard="false"
                 @click="favoritesStore.toggleFavorite(trail.id)"
               />
             </div>


### PR DESCRIPTION
## Descripción del problema
- Actualmente el componente de favorito tiene mucha lógica custom del card, así como paddings solo para el card y un atributo `isCard`.
- La usabilidad no es tan buena cuando hay un fondo que se parece al background del favorito.

## Que se hizo

- Se añadio un modifier `favorite--{type}` que condiciona que tipo de favorito se está mostrando. Se toma el caso de uso del card como `type=filled` y se deja el del show como el caso default. De esta forma el componente de favorito es más reutilizable. Esto quedó tipado con typescript para que arroje error si se pasa un tipo incorrecto.
- Se cambio el background del favorito filled a uno más blanco para que se vea mejor en imagenes con fondos parecidos
- Se añadió una animación on hover y un shadow para potenciar más el UX del componente favorito.

## Screenshots
[Screencast from 23-05-24 13:03:29.webm](https://github.com/IIC3585-2024/vue-group-04/assets/40220174/7509ecae-97d0-4262-b052-af96e0a67951)
